### PR TITLE
feat: ajuste de titulo e sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,11 +34,10 @@ st.markdown(
     """,
     unsafe_allow_html=True,
 )
-st.title("Planilha de Prazos Geral")
+st.title("Planilha de Prazos Geral 📗")
 
 # ----- Sidebar: ingestão opcional -----
 st.divider()
-st.subheader("📊 Tabelas (visualização + edição por formulário)")
 
 # Botões principais: Atualizar e Buscar Novos Dados
 col_refresh, col_fetch = st.columns([1,1])


### PR DESCRIPTION
## Summary
- adicionar ícone do Excel ao título principal
- remover subtítulo redundante na sidebar

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af64a75a84833398a255e409204a41