### PR TITLE
feat: add concluded tab

### DIFF
--- a/concluidas.sql
+++ b/concluidas.sql
@@ -1,0 +1,16 @@
+CREATE TABLE concluidas (
+    id BIGSERIAL PRIMARY KEY,
+    data DATE,
+    col_b TEXT,
+    col_c TEXT,
+    status_assunto TEXT,
+    cliente TEXT,
+    numero_processo TEXT,
+    col_g TEXT,
+    col_h TEXT,
+    col_i TEXT,
+    observacoes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_concluidas_numero_processo ON concluidas (numero_processo);

--- a/db.py
+++ b/db.py
@@ -79,3 +79,19 @@ class Agenda(Base):
     parte_adversa = Column(Text)
     sistema = Column(Text)
     created_at = Column(TIMESTAMP(timezone=True), server_default=text("now()"))
+
+
+class Concluida(Base):
+    __tablename__ = "concluidas"
+    id = Column(BigInteger, primary_key=True)
+    data = Column(Date)
+    col_b = Column(Text)
+    col_c = Column(Text)
+    status_assunto = Column(Text)
+    cliente = Column(Text)
+    numero_processo = Column(Text, index=True)
+    col_g = Column(Text)
+    col_h = Column(Text)
+    col_i = Column(Text)
+    observacoes = Column(Text)
+    created_at = Column(TIMESTAMP(timezone=True), server_default=text("now()"))


### PR DESCRIPTION
## Summary
- add SQL script to create `concluidas` table
- include model and Streamlit tab for completed records
- add 'Concluído' button to move rows into `concluidas`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0e877cfb4833380a952bbb957815a