### PR TITLE
Recreate andamentos/publicacoes with new column order

### DIFF
--- a/andamentos_publicacoes_update.sql
+++ b/andamentos_publicacoes_update.sql
@@ -1,38 +1,33 @@
--- Atualização das tabelas andamentos e publicacoes para o novo esquema
+-- Recria as tabelas andamentos e publicacoes com novo esquema
+DROP TABLE IF EXISTS andamentos;
+DROP TABLE IF EXISTS publicacoes;
 
--- Tabela andamentos
-ALTER TABLE andamentos RENAME COLUMN data TO d;
-ALTER TABLE andamentos RENAME COLUMN numero_processo TO processo;
-ALTER TABLE andamentos DROP COLUMN IF EXISTS col_b;
-ALTER TABLE andamentos DROP COLUMN IF EXISTS col_c;
-ALTER TABLE andamentos DROP COLUMN IF EXISTS status_assunto;
-ALTER TABLE andamentos DROP COLUMN IF EXISTS col_g;
-ALTER TABLE andamentos DROP COLUMN IF EXISTS col_h;
-ALTER TABLE andamentos DROP COLUMN IF EXISTS col_i;
-ALTER TABLE andamentos ADD COLUMN IF NOT EXISTS inicio_prazo DATE;
-ALTER TABLE andamentos ADD COLUMN IF NOT EXISTS fim_prazo DATE;
-ALTER TABLE andamentos ADD COLUMN IF NOT EXISTS dias_restantes INTEGER;
-ALTER TABLE andamentos ADD COLUMN IF NOT EXISTS setor TEXT;
-ALTER TABLE andamentos ADD COLUMN IF NOT EXISTS para_ramon_e_adriana_despacharem TEXT;
-ALTER TABLE andamentos ADD COLUMN IF NOT EXISTS status TEXT;
-ALTER TABLE andamentos ADD COLUMN IF NOT EXISTS resposta_do_colaborador TEXT;
-CREATE INDEX IF NOT EXISTS idx_andamentos_processo ON andamentos (processo);
+CREATE TABLE andamentos (
+    id BIGSERIAL PRIMARY KEY,
+    inicio_prazo DATE,
+    fim_prazo DATE,
+    dias_restantes INTEGER,
+    setor TEXT,
+    cliente TEXT,
+    processo TEXT,
+    para_ramon_e_adriana_despacharem TEXT,
+    status TEXT,
+    resposta_do_colaborador TEXT,
+    observacoes TEXT
+);
+CREATE INDEX idx_andamentos_processo ON andamentos (processo);
 
--- Tabela publicacoes
-ALTER TABLE publicacoes RENAME COLUMN data TO d;
-ALTER TABLE publicacoes RENAME COLUMN numero_processo TO processo;
-ALTER TABLE publicacoes DROP COLUMN IF EXISTS col_b;
-ALTER TABLE publicacoes DROP COLUMN IF EXISTS col_c;
-ALTER TABLE publicacoes DROP COLUMN IF EXISTS col_d;
-ALTER TABLE publicacoes DROP COLUMN IF EXISTS col_g;
-ALTER TABLE publicacoes DROP COLUMN IF EXISTS col_h;
-ALTER TABLE publicacoes DROP COLUMN IF EXISTS col_i;
-ALTER TABLE publicacoes ADD COLUMN IF NOT EXISTS inicio_prazo DATE;
-ALTER TABLE publicacoes ADD COLUMN IF NOT EXISTS fim_prazo DATE;
-ALTER TABLE publicacoes ADD COLUMN IF NOT EXISTS dias_restantes INTEGER;
-ALTER TABLE publicacoes ADD COLUMN IF NOT EXISTS setor TEXT;
-ALTER TABLE publicacoes ADD COLUMN IF NOT EXISTS para_ramon_e_adriana_despacharem TEXT;
-ALTER TABLE publicacoes ADD COLUMN IF NOT EXISTS status TEXT;
-ALTER TABLE publicacoes ADD COLUMN IF NOT EXISTS resposta_do_colaborador TEXT;
-CREATE INDEX IF NOT EXISTS idx_publicacoes_processo ON publicacoes (processo);
-
+CREATE TABLE publicacoes (
+    id BIGSERIAL PRIMARY KEY,
+    inicio_prazo DATE,
+    fim_prazo DATE,
+    dias_restantes INTEGER,
+    setor TEXT,
+    cliente TEXT,
+    processo TEXT,
+    para_ramon_e_adriana_despacharem TEXT,
+    status TEXT,
+    resposta_do_colaborador TEXT,
+    observacoes TEXT
+);
+CREATE INDEX idx_publicacoes_processo ON publicacoes (processo);

--- a/app.py
+++ b/app.py
@@ -17,8 +17,8 @@ from db import engine, SessionLocal, Andamento, Publicacao, Agenda, Concluida
 
 @st.cache_data(show_spinner=False)
 def _load_tables():
-    df1 = pd.read_sql("select * from andamentos order by created_at desc", engine)
-    df2 = pd.read_sql("select * from publicacoes order by created_at desc", engine)
+    df1 = pd.read_sql("select * from andamentos order by id desc", engine)
+    df2 = pd.read_sql("select * from publicacoes order by id desc", engine)
     df3 = pd.read_sql("select * from agenda order by created_at desc", engine)
     df4 = pd.read_sql("select * from concluidas order by created_at desc", engine)
     return df1, df2, df3, df4
@@ -138,7 +138,7 @@ def _move_to_concluidas(model, rec_id: Optional[int]):
         if rec is None:
             return
         values = {
-            "d": getattr(rec, "d", None) or getattr(rec, "data", None),
+            "d": getattr(rec, "inicio_prazo", None) or getattr(rec, "data", None),
             "inicio_prazo": getattr(rec, "inicio_prazo", None),
             "fim_prazo": getattr(rec, "fim_prazo", None),
             "dias_restantes": getattr(rec, "dias_restantes", None),
@@ -178,7 +178,6 @@ with tab1:
         row = _row_by_id(df1, target)
 
         with st.form("form_andamentos", clear_on_submit=False):
-            d = st.date_input("d", value=_to_date(row["d"]) if row is not None else None)
             inicio_prazo = st.date_input("inicio_prazo", value=_to_date(row["inicio_prazo"]) if row is not None else None)
             fim_prazo = st.date_input("fim_prazo", value=_to_date(row["fim_prazo"]) if row is not None else None)
             dias_restantes = st.number_input(
@@ -218,7 +217,6 @@ with tab1:
                 concluded = st.form_submit_button("Concluído", use_container_width=True, disabled=target is None)
             if submitted:
                 values = {
-                    "d": d,
                     "inicio_prazo": inicio_prazo or None,
                     "fim_prazo": fim_prazo or None,
                     "dias_restantes": int(dias_restantes) if dias_restantes is not None else None,
@@ -258,7 +256,6 @@ with tab2:
         row = _row_by_id(df2, target)
 
         with st.form("form_publicacoes", clear_on_submit=False):
-            d = st.date_input("d", value=_to_date(row["d"]) if row is not None else None)
             inicio_prazo = st.date_input("inicio_prazo", value=_to_date(row["inicio_prazo"]) if row is not None else None)
             fim_prazo = st.date_input("fim_prazo", value=_to_date(row["fim_prazo"]) if row is not None else None)
             dias_restantes = st.number_input(
@@ -298,7 +295,6 @@ with tab2:
                 concluded = st.form_submit_button("Concluído", use_container_width=True, disabled=target is None)
             if submitted:
                 values = {
-                    "d": d,
                     "inicio_prazo": inicio_prazo or None,
                     "fim_prazo": fim_prazo or None,
                     "dias_restantes": int(dias_restantes) if dias_restantes is not None else None,

--- a/db.py
+++ b/db.py
@@ -35,7 +35,6 @@ Base = declarative_base()
 class Andamento(Base):
     __tablename__ = "andamentos"
     id = Column(BigInteger, primary_key=True)
-    d = Column(Date)
     inicio_prazo = Column(Date)
     fim_prazo = Column(Date)
     dias_restantes = Column(Integer)
@@ -46,12 +45,10 @@ class Andamento(Base):
     status = Column(Text)
     resposta_do_colaborador = Column(Text)
     observacoes = Column(Text)
-    created_at = Column(TIMESTAMP(timezone=True), server_default=text("now()"))
 
 class Publicacao(Base):
     __tablename__ = "publicacoes"
     id = Column(BigInteger, primary_key=True)
-    d = Column(Date)
     inicio_prazo = Column(Date)
     fim_prazo = Column(Date)
     dias_restantes = Column(Integer)
@@ -62,7 +59,6 @@ class Publicacao(Base):
     status = Column(Text)
     resposta_do_colaborador = Column(Text)
     observacoes = Column(Text)
-    created_at = Column(TIMESTAMP(timezone=True), server_default=text("now()"))
 
 class Agenda(Base):
     __tablename__ = "agenda"

--- a/scrap_email.py
+++ b/scrap_email.py
@@ -493,8 +493,7 @@ def extrair_nomes_do_corpo(texto: str) -> str:
 # ====== Persistência no DB ======
 def add_andamento(session, data_str, setor, nomes_clientes, numero_processo, eventos_limpos):
     rec = Andamento(
-        d=to_date_or_none(data_str),
-        inicio_prazo=None,
+        inicio_prazo=to_date_or_none(data_str),
         fim_prazo=None,
         dias_restantes=None,
         setor=setor or "",
@@ -509,8 +508,7 @@ def add_andamento(session, data_str, setor, nomes_clientes, numero_processo, eve
 
 def add_publicacao(session, data_pub, nome_cliente, processo, evento_texto):
     rec = Publicacao(
-        d=to_date_or_none(data_pub),
-        inicio_prazo=None,
+        inicio_prazo=to_date_or_none(data_pub),
         fim_prazo=None,
         dias_restantes=None,
         setor="",


### PR DESCRIPTION
## Summary
- replace `andamentos` and `publicacoes` tables with new schema
- remove legacy columns from models and forms
- update email ingestion to populate new fields

## Testing
- `python -m py_compile app.py db.py scrap_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68b10ee6e89083339377b134ab86385b