### PR TITLE
Handle missing created_at column for concluidas

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from typing import Optional, Dict, Any
 import streamlit as st
 import pandas as pd
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import ProgrammingError
 
 from db import engine, SessionLocal, Andamento, Publicacao, Agenda, Concluida
 
@@ -20,7 +21,10 @@ def _load_tables():
     df1 = pd.read_sql("select * from andamentos order by id desc", engine)
     df2 = pd.read_sql("select * from publicacoes order by id desc", engine)
     df3 = pd.read_sql("select * from agenda order by created_at desc", engine)
-    df4 = pd.read_sql("select * from concluidas order by created_at desc", engine)
+    try:
+        df4 = pd.read_sql("select * from concluidas order by created_at desc", engine)
+    except ProgrammingError:
+        df4 = pd.read_sql("select * from concluidas order by id desc", engine)
     return df1, df2, df3, df4
 
 st.set_page_config(page_title="E-mails → Banco (Form Editor estável)", layout="wide")


### PR DESCRIPTION
## Summary
- Fallback to `id` sorting if `created_at` column is unavailable when loading `concluidas`

## Testing
- `python -m py_compile app.py db.py scrap_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68b120489b148333bb177a7d4bcfe2f8