### PR TITLE
feat: reposiciona botão de conclusão

### DIFF
--- a/app.py
+++ b/app.py
@@ -189,6 +189,23 @@ with tab1:
         target = None if escolha == "<novo>" else int(escolha)
         row = _row_by_id(df1, target)
 
+        concluded = st.button(
+            "Marcar como Concluída",
+            use_container_width=True,
+            disabled=target is None,
+            key="concl_andamento",
+        )
+        st.markdown(
+            """
+            <style>
+            button[data-testid="baseButton-concl_andamento"] {
+                background-color: #90EE90;
+            }
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+
         with st.form("form_andamentos", clear_on_submit=False):
             inicio_prazo = st.date_input("inicio_prazo", value=_to_date(row["inicio_prazo"]) if row is not None else None)
             fim_prazo = st.date_input("fim_prazo", value=_to_date(row["fim_prazo"]) if row is not None else None)
@@ -220,13 +237,11 @@ with tab1:
                 value=_text(row["observacoes"]) if row is not None else "",
                 height=120,
             )
-            col_save, col_del, col_done = st.columns([2.5, 1, 1])
+            col_save, col_del = st.columns([2.5, 1])
             with col_save:
                 submitted = st.form_submit_button("💾 Salvar ANDAMENTO", use_container_width=True)
             with col_del:
                 deleted = st.form_submit_button("🗑️ Excluir", use_container_width=True, disabled=target is None)
-            with col_done:
-                concluded = st.form_submit_button("Concluído", use_container_width=True, disabled=target is None)
             if submitted:
                 values = {
                     "inicio_prazo": inicio_prazo or None,
@@ -245,9 +260,9 @@ with tab1:
             if deleted and target is not None:
                 _delete_row(Andamento, target)
                 _reload("Excluído com sucesso.")
-            if concluded and target is not None:
-                _move_to_concluidas(Andamento, target)
-                _reload("Movido para Concluídas.")
+        if concluded and target is not None:
+            _move_to_concluidas(Andamento, target)
+            _reload("Movido para Concluídas.")
 
 # ---------- PUBLICAÇÕES ----------
 with tab2:
@@ -263,6 +278,23 @@ with tab2:
 
         target = None if escolha == "<novo>" else int(escolha)
         row = _row_by_id(df2, target)
+
+        concluded = st.button(
+            "Marcar como Concluída",
+            use_container_width=True,
+            disabled=target is None,
+            key="concl_publicacao",
+        )
+        st.markdown(
+            """
+            <style>
+            button[data-testid="baseButton-concl_publicacao"] {
+                background-color: #90EE90;
+            }
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
 
         with st.form("form_publicacoes", clear_on_submit=False):
             inicio_prazo = st.date_input("inicio_prazo", value=_to_date(row["inicio_prazo"]) if row is not None else None)
@@ -295,13 +327,11 @@ with tab2:
                 value=_text(row["observacoes"]) if row is not None else "",
                 height=120,
             )
-            col_save, col_del, col_done = st.columns([2.5, 1, 1])
+            col_save, col_del = st.columns([2.5, 1])
             with col_save:
                 submitted = st.form_submit_button("💾 Salvar PUBLICAÇÃO", use_container_width=True)
             with col_del:
                 deleted = st.form_submit_button("🗑️ Excluir", use_container_width=True, disabled=target is None)
-            with col_done:
-                concluded = st.form_submit_button("Concluído", use_container_width=True, disabled=target is None)
             if submitted:
                 values = {
                     "inicio_prazo": inicio_prazo or None,
@@ -320,9 +350,9 @@ with tab2:
             if deleted and target is not None:
                 _delete_row(Publicacao, target)
                 _reload("Excluído com sucesso.")
-            if concluded and target is not None:
-                _move_to_concluidas(Publicacao, target)
-                _reload("Movido para Concluídas.")
+        if concluded and target is not None:
+            _move_to_concluidas(Publicacao, target)
+            _reload("Movido para Concluídas.")
 
 # ---------- AGENDA ----------
 with tab3:
@@ -339,6 +369,23 @@ with tab3:
         target = None if escolha == "<novo>" else int(escolha)
         row = _row_by_id(df3, target)
 
+        concluded = st.button(
+            "Marcar como Concluída",
+            use_container_width=True,
+            disabled=target is None,
+            key="concl_agenda",
+        )
+        st.markdown(
+            """
+            <style>
+            button[data-testid="baseButton-concl_agenda"] {
+                background-color: #90EE90;
+            }
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+
         with st.form("form_agenda", clear_on_submit=False):
             idx = st.text_input("idx", value=_text(row["idx"]) if row is not None else "")
             data = st.date_input("data", value=_to_date(row["data"]) if row is not None else None)
@@ -353,13 +400,11 @@ with tab3:
             materia = st.text_input("materia", value=_text(row["materia"]) if row is not None else "")
             parte_adversa = st.text_input("parte_adversa", value=_text(row["parte_adversa"]) if row is not None else "")
             sistema = st.text_input("sistema", value=_text(row["sistema"]) if row is not None else "")
-            col_save, col_del, col_done = st.columns([2.5, 1, 1])
+            col_save, col_del = st.columns([2.5, 1])
             with col_save:
                 submitted = st.form_submit_button("💾 Salvar AGENDA", use_container_width=True)
             with col_del:
                 deleted = st.form_submit_button("🗑️ Excluir", use_container_width=True, disabled=target is None)
-            with col_done:
-                concluded = st.form_submit_button("Concluído", use_container_width=True, disabled=target is None)
             if submitted:
                 values = {
                     "idx": int(idx) if idx and idx.strip().isdigit() else None,
@@ -381,9 +426,9 @@ with tab3:
             if deleted and target is not None:
                 _delete_row(Agenda, target)
                 _reload("Excluído com sucesso.")
-            if concluded and target is not None:
-                _move_to_concluidas(Agenda, target)
-                _reload("Movido para Concluídas.")
+        if concluded and target is not None:
+            _move_to_concluidas(Agenda, target)
+            _reload("Movido para Concluídas.")
 
 # ---------- CONCLUÍDAS ----------
 with tab4:


### PR DESCRIPTION
## Summary
- reposiciona botão de conclusão para baixo do seletor de linha
- renomeia botão para 'Marcar como Concluída' e aplica fundo verde claro

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b12161befc8333b7690968f74660d1