### PR TITLE
Ensure last email check timestamp is stored even without new messages

### DIFF
--- a/scrap_email.py
+++ b/scrap_email.py
@@ -738,9 +738,14 @@ def buscar_e_processar_emails():
 
     mail.logout()
 
-    # Atualiza marca de tempo
-    if max_data_processada > ultima_data:
-        salvar_ultima_data(max_data_processada)
+    # Atualiza marca de tempo sempre que a busca é executada.
+    # Se não houver e-mails novos (max_data_processada == ultima_data),
+    # salva o momento atual para registrar que a verificação ocorreu.
+    salvar_ultima_data(
+        max_data_processada
+        if max_data_processada > ultima_data
+        else datetime.now(timezone.utc)
+    )
 
     print(f"✅ Banco atualizado com {emails_processados_count} novos itens.")
 


### PR DESCRIPTION
## Summary
- Always update `last_checked` table after each email scan, even if no new messages are found

## Testing
- `python -m py_compile scrap_email.py db.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b126252e6c833388f469a01c95638a