### PR TITLE
Clampeia data futura da última ingestão

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ import pandas as pd
 from sqlalchemy import text, inspect
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import ProgrammingError
-from datetime import timezone, timedelta
+from datetime import timezone, timedelta, datetime
 
 from db import (
     engine,
@@ -68,6 +68,9 @@ def _last_email_update() -> Optional[str]:
                 dt = rec.checked_at.astimezone(timezone(timedelta(hours=-3)))
             except Exception:
                 dt = rec.checked_at
+            now = datetime.now(timezone(timedelta(hours=-3)))
+            if dt > now:
+                dt = now
             return dt.strftime("%d/%m/%Y %H:%M")
     return None
 

--- a/scrap_email.py
+++ b/scrap_email.py
@@ -120,6 +120,9 @@ def salvar_ultima_data(dt: datetime):
         dt_local = dt.astimezone(fuso_brasil)
     else:
         dt_local = dt.replace(tzinfo=fuso_brasil)
+    now_local = datetime.now(fuso_brasil)
+    if dt_local > now_local:
+        dt_local = now_local
     with SessionLocal() as db:
         rec = db.query(LastChecked).first()
         if rec:


### PR DESCRIPTION
## Summary
- Evita salvar ou exibir marcações de tempo futuras na atualização de e-mails

## Testing
- `python -m py_compile app.py scrap_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4ffad276083338cc0e8159270acac