### PR TITLE
Colorir linhas por setor

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from sqlalchemy import text, inspect
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import ProgrammingError
 from datetime import timezone, timedelta, datetime
+import unicodedata
 
 from db import (
     engine,
@@ -36,6 +37,42 @@ SETOR_OPTIONS = [
     "Assinatura",
     "Tainá",
 ]
+
+SETOR_COLORS = {
+    "andamento": "#cce5ff",  # azul claro
+    "livia": "#e6ccff",  # roxo claro
+    "lívia": "#e6ccff",
+    "ana clara": "#fff3cd",  # amarelo claro
+    "feito": "#d4edda",  # verde claro
+    "nada a fazer": "#d4edda",
+    "feito e nada a fazer": "#d4edda",
+    "correcao": "#ffe5b4",  # laranja claro
+    "correção": "#ffe5b4",
+    "assinatura": "#ffe5b4",
+    "correcao e assinatura": "#ffe5b4",
+    "correção e assinatura": "#ffe5b4",
+    "taina": "#d2b48c",  # marrom claro
+    "tainá": "#d2b48c",
+}
+
+
+def _normalize_setor(val: Any) -> str:
+    if val is None:
+        return ""
+    val = unicodedata.normalize("NFKD", str(val))
+    val = val.encode("ascii", "ignore").decode("ascii")
+    return val.strip().lower()
+
+
+def style_by_setor(df: pd.DataFrame):
+    if "setor" not in df.columns:
+        return df
+
+    def _style(row: pd.Series):
+        color = SETOR_COLORS.get(_normalize_setor(row.get("setor")), "")
+        return [f"background-color: {color}" if color else "" for _ in row]
+
+    return df.style.apply(_style, axis=1)
 
 @st.cache_data(show_spinner=False)
 def _load_tables():
@@ -226,7 +263,7 @@ with tab1:
     left, right = st.columns([1.7, 0.7])
     with left:
         st.markdown("#### 📄 Visualização")
-        st.dataframe(df1, use_container_width=True, height=1000, hide_index=True)
+        st.dataframe(style_by_setor(df1), use_container_width=True, height=1000, hide_index=True)
     with right:
         st.markdown("#### ✏️ Editar / Adicionar")
         ids = df1["id"].tolist() if "id" in df1.columns else []
@@ -321,7 +358,7 @@ with tab2:
     left, right = st.columns([1.7, 0.7])
     with left:
         st.markdown("#### 📄 Visualização")
-        st.dataframe(df2, use_container_width=True, height=1000, hide_index=True)
+        st.dataframe(style_by_setor(df2), use_container_width=True, height=1000, hide_index=True)
     with right:
         st.markdown("#### ✏️ Editar / Adicionar")
         ids = df2["id"].tolist() if "id" in df2.columns else []
@@ -416,7 +453,7 @@ with tab3:
     left, right = st.columns([1.7, 0.7])
     with left:
         st.markdown("#### 📄 Visualização")
-        st.dataframe(df3, use_container_width=True, height=1000, hide_index=True)
+        st.dataframe(style_by_setor(df3), use_container_width=True, height=1000, hide_index=True)
     with right:
         st.markdown("#### ✏️ Editar / Adicionar")
         ids = df3["id"].tolist() if "id" in df3.columns else []
@@ -490,6 +527,6 @@ with tab3:
 # ---------- CONCLUÍDAS ----------
 with tab4:
     st.markdown("#### 📄 Visualização")
-    st.dataframe(df4, use_container_width=True, height=1000, hide_index=True)
+    st.dataframe(style_by_setor(df4), use_container_width=True, height=1000, hide_index=True)
 
 st.caption("Dica: o modo formulário evita o rerun a cada tecla; os dados só mudam ao clicar Salvar.")


### PR DESCRIPTION
## Summary
- Color background of table rows based on the `setor` column
- Map setores to specific colors (Andamento azul, Lívia roxo, Ana Clara amarelo, Feito/Nada a Fazer verde, Correção/Assinatura laranja, Tainá marrom)
- Apply the styling to all table displays

## Testing
- `python -m py_compile app.py db.py scrap_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68b50739ddc883338f232bb8cf4899ac