### PR TITLE
Ajusta cor do texto em linhas com fundo azul

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,7 +70,12 @@ def style_by_setor(df: pd.DataFrame):
 
     def _style(row: pd.Series):
         color = SETOR_COLORS.get(_normalize_setor(row.get("setor")), "")
-        return [f"background-color: {color}" if color else "" for _ in row]
+        if not color:
+            return ["" for _ in row]
+        style = f"background-color: {color};"
+        if color.lower() == "#cce5ff":  # linhas com fundo azul
+            style += " color: black;"
+        return [style for _ in row]
 
     return df.style.apply(_style, axis=1)
 


### PR DESCRIPTION
## Summary
- força cor preta do texto em linhas com fundo azul nos dataframes

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b58d6b151c8333a928abfa5b6af3cb