### PR TITLE
Ensure black text for yellow rows

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,7 +85,7 @@ def style_by_setor(df: pd.DataFrame):
         if not color:
             return ["" for _ in row]
         style = f"background-color: {color};"
-        if color.lower() in ("#cce5ff", "#d4edda"):  # linhas com fundo azul ou verde
+        if color.lower() in ("#cce5ff", "#d4edda", "#fff3cd"):  # linhas com fundo azul, verde ou amarelo
             style += " color: black;"
         return [style for _ in row]
 


### PR DESCRIPTION
## Summary
- Use black text when table rows have a yellow background

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5f64751fc8333a7e754be60718b48