### PR TITLE
Substitui select de setor por campo de texto

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,17 +27,6 @@ from db import (
     LastChecked,
 )
 
-# Opções fixas para o campo "setor" em todos os formulários
-SETOR_OPTIONS = [
-    "Andamento",
-    "Lívia",
-    "Ana Clara",
-    "Nada a Fazer",
-    "Correção",
-    "Assinatura",
-    "Tainá",
-]
-
 # Opções fixas para o campo "status" em todos os formulários
 STATUS_OPTIONS = [
     "Feito",
@@ -339,12 +328,7 @@ with tab1:
                 value=int(row["dias_restantes"]) if row is not None and not pd.isna(row["dias_restantes"]) else 0,
                 step=1,
             )
-            setor_index = (
-                SETOR_OPTIONS.index(row["setor"])
-                if row is not None and row["setor"] in SETOR_OPTIONS
-                else 0
-            )
-            setor = st.selectbox("setor", SETOR_OPTIONS, index=setor_index)
+            setor = st.text_input("setor", value=_text(row["setor"]) if row is not None else "")
             cliente = st.text_input("cliente", value=_text(row["cliente"]) if row is not None else "")
             processo = st.text_input("processo", value=_text(row["processo"]) if row is not None else "")
             para_ramon_e_adriana_despacharem = st.text_input(
@@ -453,12 +437,7 @@ with tab2:
                 value=int(row["dias_restantes"]) if row is not None and not pd.isna(row["dias_restantes"]) else 0,
                 step=1,
             )
-            setor_index = (
-                SETOR_OPTIONS.index(row["setor"])
-                if row is not None and row["setor"] in SETOR_OPTIONS
-                else 0
-            )
-            setor = st.selectbox("setor", SETOR_OPTIONS, index=setor_index)
+            setor = st.text_input("setor", value=_text(row["setor"]) if row is not None else "")
             cliente = st.text_input("cliente", value=_text(row["cliente"]) if row is not None else "")
             processo = st.text_input("processo", value=_text(row["processo"]) if row is not None else "")
             para_ramon_e_adriana_despacharem = st.text_input(


### PR DESCRIPTION
## Summary
- remove opções fixas de setor
- usa campo de texto para setor em Andamentos e Publicações

## Testing
- `python -m py_compile app.py db.py scrap_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68b70f5fca948333bd865a60f0d3d4c1