### PR TITLE
Não preencher automaticamente o status com "Em Andamento"

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,7 @@ SETOR_OPTIONS = [
 
 # Opções fixas para o campo "status" em todos os formulários
 STATUS_OPTIONS = [
+    "",
     "Feito",
     "Correção",
     "Assinatura",

--- a/scrap_email.py
+++ b/scrap_email.py
@@ -531,7 +531,7 @@ def add_andamento(session, data_str, setor, nomes_clientes, numero_processo, eve
         cliente=nomes_clientes or "",
         processo=numero_processo or "",
         para_ramon_e_adriana_despacharem="",
-        status="Em Andamento",
+        status="",
         resposta_do_colaborador="",
         observacoes=eventos_limpos or "",
     )
@@ -546,7 +546,7 @@ def add_publicacao(session, data_pub, nome_cliente, processo, evento_texto):
         cliente=nome_cliente or "",
         processo=processo or "",
         para_ramon_e_adriana_despacharem="",
-        status="Em Andamento",
+        status="",
         resposta_do_colaborador="",
         observacoes=evento_texto or "",
     )


### PR DESCRIPTION
## Summary
- Evita atribuição automática de "Em Andamento" ao criar andamentos e publicações
- Adiciona opção vazia às opções fixas de status para edição manual

## Testing
- `python -m compileall -q .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70fb64e048333a9dc5962bbb3bd81