### PR TITLE
Ajusta margem do botão de menu

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,6 +154,7 @@ if "filter_date" not in st.session_state:
 
 menu_col, title_col = st.columns([0.1, 0.9])
 with menu_col:
+    st.markdown("<div style='margin-top: 1rem'></div>", unsafe_allow_html=True)
     if st.button("☰ Menu", use_container_width=True):
         st.session_state["show_settings"] = True
 with title_col:


### PR DESCRIPTION
## Summary
- Adiciona margem superior ao botão de menu para evitar sobreposição com o cabeçalho

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b8920cbfe88333a79caebaf61e3f0b