### PR TITLE
Adjust menu button spacing

### DIFF
--- a/app.py
+++ b/app.py
@@ -164,7 +164,7 @@ if "filter_date" not in st.session_state:
 
 menu_col, title_col = st.columns([0.1, 0.9])
 with menu_col:
-    st.markdown("<div style='margin-top: 1rem'></div>", unsafe_allow_html=True)
+    st.markdown("<div style='margin-top: 1.2rem'></div>", unsafe_allow_html=True)
     if st.button("☰ Menu", use_container_width=True):
         st.session_state["show_settings"] = True
 with title_col:


### PR DESCRIPTION
## Summary
- Increase top margin for the menu button to push it down by about 20%

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b90bdcea188333b162004a52100508