### PR TITLE
Adicionar aba Financeiro para setor Livia

### DIFF
--- a/db.py
+++ b/db.py
@@ -60,6 +60,21 @@ class Publicacao(Base):
     resposta_do_colaborador = Column(Text)
     observacoes = Column(Text)
 
+
+class Financeiro(Base):
+    __tablename__ = "financeiro"
+    id = Column(BigInteger, primary_key=True)
+    inicio_prazo = Column(Date)
+    fim_prazo = Column(Date)
+    dias_restantes = Column(Integer)
+    setor = Column(Text)
+    cliente = Column(Text)
+    processo = Column(Text, index=True)
+    para_ramon_e_adriana_despacharem = Column(Text)
+    status = Column(Text)
+    resposta_do_colaborador = Column(Text)
+    observacoes = Column(Text)
+
 class Agenda(Base):
     __tablename__ = "agenda"
     id = Column(BigInteger, primary_key=True)

--- a/financeiro.sql
+++ b/financeiro.sql
@@ -1,0 +1,17 @@
+-- Cria a tabela financeiro para registros do setor Lívia
+DROP TABLE IF EXISTS financeiro;
+
+CREATE TABLE financeiro (
+    id BIGSERIAL PRIMARY KEY,
+    inicio_prazo DATE,
+    fim_prazo DATE,
+    dias_restantes INTEGER,
+    setor TEXT,
+    cliente TEXT,
+    processo TEXT,
+    para_ramon_e_adriana_despacharem TEXT,
+    status TEXT,
+    resposta_do_colaborador TEXT,
+    observacoes TEXT
+);
+CREATE INDEX idx_financeiro_processo ON financeiro (processo);


### PR DESCRIPTION
## Summary
- criar tabela e modelo Financeiro separados de Publicações
- exibir dados de Financeiro em nova aba "Financeiro e Solicitação de Documentos" com ações de mover para outras listas
- mover automaticamente publicações do setor Lívia para a tabela Financeiro

## Testing
- `python -m py_compile app.py`
- `python -m py_compile db.py scrap_email.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf8bf714dc83339d4ff3445e083aaf