### PR TITLE
Adiciona filtro do setor para Financeiro

### DIFF
--- a/app.py
+++ b/app.py
@@ -684,7 +684,7 @@ with tab2:
                         "resposta_do_colaborador": resposta_do_colaborador or None,
                         "observacoes": observacoes or None,
                     }
-                    if setor.strip().lower() == "livia":
+                    if setor.strip().lower() in {"livia", "financeiro", "setor financeiro"}:
                         _save_row(Financeiro, None, values)
                         if target is not None:
                             _delete_row(Publicacao, target)


### PR DESCRIPTION
## Summary
- Permite que valores "Financeiro", "financeiro" ou "Setor Financeiro" na coluna de setor movam automaticamente o registro para a aba Financeiro

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0687575748333864270df3cdaed21