### PR TITLE
Add Streamlit entrypoint with dynamic PORT support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,12 @@
+import os
+from streamlit.web import bootstrap
+
+
+def main():
+    port = int(os.environ.get("PORT", 8501))
+    address = "0.0.0.0"
+    bootstrap.run("app.py", False, [], {"server.port": port, "server.address": address})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `main.py` entrypoint that boots Streamlit on the port defined by the `PORT` environment variable so Railway deploys can bind correctly

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c35dada1408333b85abcfedc866535