### PR TITLE
Definir padrão do calendário para conta mtsilva2303

### DIFF
--- a/calendar_integration.py
+++ b/calendar_integration.py
@@ -260,7 +260,7 @@ class AgendaCalendarClient:
             _coerce_str(
                 _get_config_value(["GOOGLE_CALENDAR_ID", "CALENDAR_ID", "CALENDAR"])
             )
-            or "primary"
+            or "mtsilva2303@gmail.com"
         )
 
     def _ensure_service(self):


### PR DESCRIPTION
## Summary
- ajusta o identificador padrão do Google Calendar para usar o endereço mtsilva2303@gmail.com quando nenhuma configuração explícita é fornecida

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db3e86b3f483339fd32f1d361437a8