### PR TITLE
Refactor calendar integration to use gcsa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ psycopg2-binary
 beautifulsoup4
 openpyxl
 streamlit-aggrid
-google-api-python-client
+gcsa


### PR DESCRIPTION
## Summary
- replace the previous Google Calendar client implementation with gcsa-based integration
- adjust event synchronization and deletion logic to use gcsa Event helpers and timezone handling
- add the gcsa dependency to the project requirements

## Testing
- python -m compileall calendar_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68db470cf13c8333bc36c5e0e9ce044a