### PR TITLE
Fix Google Calendar dependency name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ psycopg2-binary
 beautifulsoup4
 openpyxl
 streamlit-aggrid
-google-calendar-simple-api
+gcsa


### PR DESCRIPTION
## Summary
- replace the deprecated google-calendar-simple-api requirement with the maintained gcsa package

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc87eb7e148333ad6bc65374464242