### PR TITLE
Fix GoogleCalendar initialization parameter

### DIFF
--- a/calendar_integration.py
+++ b/calendar_integration.py
@@ -256,7 +256,7 @@ class CalendarService:
 
         try:
             calendar = GoogleCalendar(
-                calendar=self._calendar_id,
+                default_calendar=self._calendar_id,
                 credentials=credentials,
             )
         except Exception as exc:  # pragma: no cover - depende da API externa


### PR DESCRIPTION
## Summary
- fix the GoogleCalendar client initialization to use the correct `default_calendar` keyword when selecting the target calendar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc8e828de4833387889d1380406785